### PR TITLE
Update Twilio Video Android to 7.0.3

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2021 Denis Kornev
+Copyright (c) 2021 Xamarin Binding Community for Twilio
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -4,12 +4,12 @@ Twilio Video Android SDK binding for Xamarin
 
 [![NuGet][nuget-img]][nuget-link]
 
-[nuget-img]: https://img.shields.io/badge/nuget7.0.2.0-blue.svg
+[nuget-img]: https://img.shields.io/badge/nuget7.0.3.0-blue.svg
 [nuget-link]: https://www.nuget.org/packages/Twilio.Video.Android.XamarinBinding
 
 ## How to Build
 
-### Twilio.Video Android 7.0.2 (November 3rd, 2021)
+### Twilio.Video Android 7.0.3 (December 6th, 2021)
 
 _AndroidDexTool_ should be set to _d8_ for _TargetFrameworkVersion_ == _v9.0_ or later.
 You also need ReLinker Xamarin Bindings for Android: https://github.com/xbindings/relinker-android-binding
@@ -21,9 +21,9 @@ or
 
 Download aar/jar version you needed from https://bintray.com/twilio/releases/video-android and copy it to src\Jars. Then you will need to change res/values/values.xml and add missing \<attr format="boolean" name="overlaySurface"/> attribute if needed. And rename /src/Jars/ARR/libs/libwebrtc.jar to libwebrtc_2.jar if you are going to use Twilio.Voice SDK in you project.
 ```    
-$ unzip video-android-7.0.2.aar -d tempFolder    
+$ unzip video-android-7.0.3.aar -d tempFolder    
 # Change whatever you need    
-$ jar cvf video-android-7.0.2.aar -C tempFolder/ .
+$ jar cvf video-android-7.0.3.aar -C tempFolder/ .
 ```
 
 #### Changed properties

--- a/README.md
+++ b/README.md
@@ -4,12 +4,12 @@ Twilio Video Android SDK binding for Xamarin
 
 [![NuGet][nuget-img]][nuget-link]
 
-[nuget-img]: https://img.shields.io/badge/nuget-6.2.1.0-blue.svg
+[nuget-img]: https://img.shields.io/badge/nuget7.0.2.0-blue.svg
 [nuget-link]: https://www.nuget.org/packages/Twilio.Video.Android.XamarinBinding
 
 ## How to Build
 
-### Twilio.Video Android 6.2.1 (January 25th, 2021)
+### Twilio.Video Android 7.0.2 (November 3rd, 2021)
 
 _AndroidDexTool_ should be set to _d8_ for _TargetFrameworkVersion_ == _v9.0_ or later.
 You also need ReLinker Xamarin Bindings for Android: https://github.com/xbindings/relinker-android-binding
@@ -21,9 +21,9 @@ or
 
 Download aar/jar version you needed from https://bintray.com/twilio/releases/video-android and copy it to src\Jars. Then you will need to change res/values/values.xml and add missing \<attr format="boolean" name="overlaySurface"/> attribute if needed. And rename /src/Jars/ARR/libs/libwebrtc.jar to libwebrtc_2.jar if you are going to use Twilio.Voice SDK in you project.
 ```    
-$ unzip video-android-6.2.1.aar -d tempFolder    
+$ unzip video-android-7.0.2.aar -d tempFolder    
 # Change whatever you need    
-$ jar cvf video-android-6.2.1.aar -C tempFolder/ .
+$ jar cvf video-android-7.0.2.aar -C tempFolder/ .
 ```
 
 #### Changed properties
@@ -31,24 +31,17 @@ ScaleType, mirror, or overlaySurface have been prefixed. These attributes define
 
 ##### Proguard settings
 
--keep class org.webrtc.** { *; }
--dontwarn org.webrtc.**
+-keep class tvi.webrtc.** { *; }
 -keep class com.twilio.video.** { *; }
--keep class com.twilio.common.** { *; }
 -keepattributes InnerClasses
 
 ## Sample
 
-####  I don't have C# version of twilio quickstart application, so I highly recommend you to read about using native library bindings for xamarin and check official Twilio quickstart guides.
+####  We don't have C# version of twilio quickstart application, so I highly recommend you to read about using native library bindings for xamarin and check official Twilio quickstart guides.
 
 [video-quickstart-android](https://github.com/twilio/video-quickstart-android)
 
 ## Contributions
-
-Members of the community have contributed to improving and update bindings:
-
-- [Jørgen](https://github.com/jtorvald)
-- [Guillermo Gerard](https://github.com/guillermo-gerard)
 
 If you have a bugfix or an update you'd like to add, please open an issue. 
 All pull requests should be opened against the `master` branch.

--- a/src/Twilio.Video.Android.csproj
+++ b/src/Twilio.Video.Android.csproj
@@ -67,7 +67,7 @@
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
     <PackageReference Include="Xamarin.ReLinker">
-      <Version>1.4.3</Version>
+      <Version>1.4.4</Version>
     </PackageReference>
   </ItemGroup>
   <Import Project="$(MSBuildExtensionsPath)\Xamarin\Android\Xamarin.Android.Bindings.targets" />

--- a/src/Twilio.Video.Android.csproj
+++ b/src/Twilio.Video.Android.csproj
@@ -53,7 +53,7 @@
   <ItemGroup>
     <None Include="Jars\AboutJars.txt" />
     <None Include="Additions\AboutAdditions.txt" />
-    <LibraryProjectZip Include="Jars\video-android-7.0.2.aar" />
+    <LibraryProjectZip Include="Jars\video-android-7.0.3.aar" />
   </ItemGroup>
   <ItemGroup>
     <TransformFile Include="Transforms\Metadata.xml" />

--- a/src/Twilio.Video.Android.csproj
+++ b/src/Twilio.Video.Android.csproj
@@ -13,7 +13,7 @@
     <RootNamespace>Twilio.Video.Android</RootNamespace>
     <AssemblyName>Twilio.Video.Android</AssemblyName>
     <FileAlignment>512</FileAlignment>
-    <TargetFrameworkVersion>v10.0</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v11.0</TargetFrameworkVersion>
     <AndroidClassParser>class-parse</AndroidClassParser>
     <AndroidCodegenTarget>XAJavaInterop1</AndroidCodegenTarget>
     <RestoreProjectStyle>PackageReference</RestoreProjectStyle>
@@ -53,7 +53,7 @@
   <ItemGroup>
     <None Include="Jars\AboutJars.txt" />
     <None Include="Additions\AboutAdditions.txt" />
-    <LibraryProjectZip Include="Jars\video-android-6.2.1.aar" />
+    <LibraryProjectZip Include="Jars\video-android-7.0.2.aar" />
   </ItemGroup>
   <ItemGroup>
     <TransformFile Include="Transforms\Metadata.xml" />

--- a/src/build.sh
+++ b/src/build.sh
@@ -1,4 +1,4 @@
 #!/usr/bin/env bash
 
 msbuild -t:Clean,Build -p:Configuration=Release Twilio.Video.Android.csproj
-nuget pack twilio-video.nuspec 
+# nuget pack twilio-video.nuspec 

--- a/src/twilio-video.nuspec
+++ b/src/twilio-video.nuspec
@@ -2,10 +2,10 @@
 <package >
   <metadata>
     <id>Twilio.Video.Android.XamarinBinding</id>
-    <version>6.2.1.0</version>
+    <version>7.0.2.0</version>
     <authors>twilio dkornev</authors>
     <owners>twilio</owners>
-    <projectUrl>https://github.com/dkornev/TwilioVideoXamarinAndroid</projectUrl>
+    <projectUrl>https://github.com/xamarin-bindings-for-twilio/TwilioVideoXamarinAndroid</projectUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <title>Twilio Video Android SDK</title>
     <summary>Twilio Video Android SDK binding for Xamarin Android</summary>
@@ -20,6 +20,6 @@
     <!-- Optional 'files' node -->
     <files>
         <!--Android-->
-        <file src="bin/Release/Twilio.Video.Android.dll" target="lib/MonoAndroid10/Twilio.Video.Android.dll" />
+        <file src="bin/Release/Twilio.Video.Android.dll" target="lib/MonoAndroid11/Twilio.Video.Android.dll" />
     </files>
 </package>

--- a/src/twilio-video.nuspec
+++ b/src/twilio-video.nuspec
@@ -2,7 +2,7 @@
 <package >
   <metadata>
     <id>Twilio.Video.Android.XamarinBinding</id>
-    <version>7.0.2.0</version>
+    <version>7.0.3.0</version>
     <authors>twilio dkornev</authors>
     <owners>twilio</owners>
     <projectUrl>https://github.com/xamarin-bindings-for-twilio/TwilioVideoXamarinAndroid</projectUrl>


### PR DESCRIPTION
This one updated the Twilio Video Android binding to the latest 7.0.3 version https://www.twilio.com/docs/video/changelog-twilio-video-android-v7#703-december-6th-2021

I tried to mimic some changes from https://github.com/xamarin-bindings-for-twilio/TwilioVoiceXamarinIOS/pull/1 related to the readme and licensing.