### PR TITLE
Update Twilio Video Android to 7.0.6

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,12 +4,12 @@ Twilio Video Android SDK binding for Xamarin
 
 [![NuGet][nuget-img]][nuget-link]
 
-[nuget-img]: https://img.shields.io/badge/nuget7.0.4.0-blue.svg
+[nuget-img]: https://img.shields.io/badge/nuget7.0.6.0-blue.svg
 [nuget-link]: https://www.nuget.org/packages/Twilio.Video.Android.XamarinBinding
 
 ## How to Build
 
-### Twilio.Video Android 7.0.4 (February 9th, 2021)
+### Twilio.Video Android 7.0.6 (February 11th, 2022)
 
 _AndroidDexTool_ should be set to _d8_ for _TargetFrameworkVersion_ == _v9.0_ or later.
 You also need ReLinker Xamarin Bindings for Android: https://github.com/xbindings/relinker-android-binding
@@ -21,9 +21,9 @@ or
 
 Download aar/jar version you needed from https://bintray.com/twilio/releases/video-android and copy it to src\Jars. Then you will need to change res/values/values.xml and add missing \<attr format="boolean" name="overlaySurface"/> attribute if needed. And rename /src/Jars/ARR/libs/libwebrtc.jar to libwebrtc_2.jar if you are going to use Twilio.Voice SDK in you project.
 ```    
-$ unzip video-android-7.0.4.aar -d tempFolder    
+$ unzip video-android-7.0.6.aar -d tempFolder    
 # Change whatever you need    
-$ jar cvf video-android-7.0.4.aar -C tempFolder/ .
+$ jar cvf video-android-7.0.6.aar -C tempFolder/ .
 ```
 
 #### Changed properties

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Twilio Video Android SDK binding for Xamarin
 
 [![NuGet][nuget-img]][nuget-link]
 
-[nuget-img]: https://img.shields.io/badge/nuget7.0.3.0-blue.svg
+[nuget-img]: https://img.shields.io/badge/nuget7.0.3.1-blue.svg
 [nuget-link]: https://www.nuget.org/packages/Twilio.Video.Android.XamarinBinding
 
 ## How to Build

--- a/README.md
+++ b/README.md
@@ -4,12 +4,12 @@ Twilio Video Android SDK binding for Xamarin
 
 [![NuGet][nuget-img]][nuget-link]
 
-[nuget-img]: https://img.shields.io/badge/nuget7.0.3.0-blue.svg
+[nuget-img]: https://img.shields.io/badge/nuget7.0.4.0-blue.svg
 [nuget-link]: https://www.nuget.org/packages/Twilio.Video.Android.XamarinBinding
 
 ## How to Build
 
-### Twilio.Video Android 7.0.3 (December 6th, 2021)
+### Twilio.Video Android 7.0.4 (February 9th, 2021)
 
 _AndroidDexTool_ should be set to _d8_ for _TargetFrameworkVersion_ == _v9.0_ or later.
 You also need ReLinker Xamarin Bindings for Android: https://github.com/xbindings/relinker-android-binding
@@ -21,9 +21,9 @@ or
 
 Download aar/jar version you needed from https://bintray.com/twilio/releases/video-android and copy it to src\Jars. Then you will need to change res/values/values.xml and add missing \<attr format="boolean" name="overlaySurface"/> attribute if needed. And rename /src/Jars/ARR/libs/libwebrtc.jar to libwebrtc_2.jar if you are going to use Twilio.Voice SDK in you project.
 ```    
-$ unzip video-android-7.0.3.aar -d tempFolder    
+$ unzip video-android-7.0.4.aar -d tempFolder    
 # Change whatever you need    
-$ jar cvf video-android-7.0.3.aar -C tempFolder/ .
+$ jar cvf video-android-7.0.4.aar -C tempFolder/ .
 ```
 
 #### Changed properties

--- a/src/Twilio.Video.Android.csproj
+++ b/src/Twilio.Video.Android.csproj
@@ -53,7 +53,7 @@
   <ItemGroup>
     <None Include="Jars\AboutJars.txt" />
     <None Include="Additions\AboutAdditions.txt" />
-    <LibraryProjectZip Include="Jars\video-android-7.0.4.aar" />
+    <LibraryProjectZip Include="Jars\video-android-7.0.6.aar" />
   </ItemGroup>
   <ItemGroup>
     <TransformFile Include="Transforms\Metadata.xml" />
@@ -66,9 +66,9 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="Xamarin.ReLinker">
-      <Version>1.4.4</Version>
-    </PackageReference>
+    <PackageReference Include="Xamarin.ReLinker" Version="1.4.4" />
+    <PackageReference Include="Xamarin.AndroidX.Annotation" Version="1.1.0.9" />
+    <PackageReference Include="Xamarin.Kotlin.StdLib.Jdk8" Version="1.6.0" />
   </ItemGroup>
   <Import Project="$(MSBuildExtensionsPath)\Xamarin\Android\Xamarin.Android.Bindings.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 

--- a/src/Twilio.Video.Android.csproj
+++ b/src/Twilio.Video.Android.csproj
@@ -53,7 +53,7 @@
   <ItemGroup>
     <None Include="Jars\AboutJars.txt" />
     <None Include="Additions\AboutAdditions.txt" />
-    <LibraryProjectZip Include="Jars\video-android-7.0.3.aar" />
+    <LibraryProjectZip Include="Jars\video-android-7.0.4.aar" />
   </ItemGroup>
   <ItemGroup>
     <TransformFile Include="Transforms\Metadata.xml" />

--- a/src/twilio-video.nuspec
+++ b/src/twilio-video.nuspec
@@ -2,7 +2,7 @@
 <package >
   <metadata>
     <id>Twilio.Video.Android.XamarinBinding</id>
-    <version>7.0.3.0</version>
+    <version>7.0.4.0</version>
     <authors>twilio</authors>
     <owners>twilio</owners>
     <projectUrl>https://github.com/xamarin-bindings-for-twilio/TwilioVideoXamarinAndroid</projectUrl>

--- a/src/twilio-video.nuspec
+++ b/src/twilio-video.nuspec
@@ -2,7 +2,7 @@
 <package >
   <metadata>
     <id>Twilio.Video.Android.XamarinBinding</id>
-    <version>7.0.4.0</version>
+    <version>7.0.6.0</version>
     <authors>twilio</authors>
     <owners>twilio</owners>
     <projectUrl>https://github.com/xamarin-bindings-for-twilio/TwilioVideoXamarinAndroid</projectUrl>
@@ -15,6 +15,8 @@
     <tags>twilio xamarin</tags>
     <dependencies>
       <dependency id="Xamarin.ReLinker" version="1.4.4" />
+      <dependency id="Xamarin.AndroidX.Annotation" version="1.1.0.9" />
+      <dependency id="Xamarin.Kotlin.StdLib.Jdk8" version="1.6.0" />
     </dependencies>
   </metadata>
     <!-- Optional 'files' node -->

--- a/src/twilio-video.nuspec
+++ b/src/twilio-video.nuspec
@@ -2,7 +2,7 @@
 <package >
   <metadata>
     <id>Twilio.Video.Android.XamarinBinding</id>
-    <version>7.0.3.0</version>
+    <version>7.0.3.1</version>
     <authors>twilio</authors>
     <owners>twilio</owners>
     <projectUrl>https://github.com/xamarin-bindings-for-twilio/TwilioVideoXamarinAndroid</projectUrl>


### PR DESCRIPTION
This PR updated the Twilio Video Android binding to the latest version 7.0.6
https://www.twilio.com/docs/video/changelog-twilio-video-android-v7#706-february-11th-2022